### PR TITLE
[GILJOB-44] Card 컴포넌트 제작 외 다수

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,14 +24,7 @@
   },
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
-    "import/no-unresolved": [
-      "error",
-      {
-        "ignore": [
-          "custom-types"
-        ]
-      }
-    ],
+    "import/no-unresolved": "off",
     "import/extensions": [
       "error",
       "ignorePackages",
@@ -46,11 +39,13 @@
       2,
       { "extensions": [".js", ".jsx", ".ts", ".tsx"] }
     ],
+    "no-shadow": "off",
     "no-param-reassign": "off",
     "no-use-before-define": "off",
     "react/react-in-jsx-scope": "off",
     "react/jsx-props-no-spreading": "off",
     "import/no-extraneous-dependencies": "off",
+    "@typescript-eslint/no-shadow": "off",
     "@typescript-eslint/no-use-before-define": ["error"],
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off"
@@ -63,8 +58,7 @@
           "node_modules",
           "@types"
         ]
-      },
-      "typescript": "./tsconfig.json"
+      }
     }
   }
 }

--- a/config/webpack/webpack.dev.js
+++ b/config/webpack/webpack.dev.js
@@ -28,7 +28,6 @@ module.exports = merge(baseConfig, {
               sassOptions: {
                 includePaths: [path.join(PROJECT_ROOT, './src/styles')],
               },
-              additionalData: `@import "index";`,
             },
           },
         ],

--- a/config/webpack/webpack.prod.js
+++ b/config/webpack/webpack.prod.js
@@ -23,7 +23,6 @@ module.exports = merge(baseConfig, {
               sassOptions: {
                 includePaths: [path.join(PROJECT_ROOT, './src/styles')],
               },
-              additionalData: `@import "index";`,
             },
           },
         ],

--- a/src/atoms/Badge/Badge.tsx
+++ b/src/atoms/Badge/Badge.tsx
@@ -5,7 +5,7 @@ import Text from '@src/atoms/Text';
 
 export interface BadgeProps {
   className?: string;
-  step: '입문' | '통달';
+  step: '입문' | '초급' | '중급' | '고급' | '통달';
   align?: 'start' | 'center' | 'end';
 }
 

--- a/src/atoms/Badge/Badge.tsx
+++ b/src/atoms/Badge/Badge.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import cn from 'classnames';
+import './style.scss';
+import Text from '@src/atoms/Text';
+
+export interface BadgeProps {
+  className?: string;
+  step: '입문' | '통달';
+  align?: 'start' | 'center' | 'end';
+}
+
+const Badge: React.FC<BadgeProps> = ({ className, step, align }) => {
+  return (
+    <div className={cn('_BADGE_', className, `badge-align-${align}`)}>
+      <Text align="center" fontColor="white" fontSize="small" lineHeight="wide">
+        {step}
+      </Text>
+    </div>
+  );
+};
+
+export default Badge;

--- a/src/atoms/Badge/badge.stories.tsx
+++ b/src/atoms/Badge/badge.stories.tsx
@@ -1,0 +1,35 @@
+import { Story, Meta } from '@storybook/react';
+import Badge from '@src/atoms/Badge';
+import { BadgeProps } from './Badge';
+
+export default {
+  title: 'Atoms/Badge',
+  component: Badge,
+  parameters: {
+    docs: {
+      description: {
+        component: 'Badge',
+      },
+    },
+  },
+  argTypes: {
+    align: {
+      table: {
+        disable: true,
+      },
+    },
+    className: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} as Meta;
+
+const Template: Story<BadgeProps> = (args) => <Badge {...args} />;
+
+export const defaultBadge = Template.bind({});
+
+defaultBadge.args = {
+  step: '입문',
+};

--- a/src/atoms/Badge/index.ts
+++ b/src/atoms/Badge/index.ts
@@ -1,0 +1,3 @@
+import Badge from './Badge';
+
+export default Badge;

--- a/src/atoms/Badge/style.scss
+++ b/src/atoms/Badge/style.scss
@@ -1,0 +1,20 @@
+@import '/src/styles/';
+
+._BADGE_ {
+  width: 6.4rem;
+  height: 2rem;
+  border-radius: 1rem;
+  background-color: $gil-blue;
+
+  &.badge-align {
+    &-start {
+      align-self: flex-start;
+    }
+    &-center {
+      align-self: center;
+    }
+    &-end {
+      align-self: flex-end;
+    }
+  }
+}

--- a/src/atoms/Text/Text.tsx
+++ b/src/atoms/Text/Text.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import cn from 'classnames';
+import './style.scss';
+import { FontSize } from '@src/utils';
+
+export interface TextProps {
+  className?: string;
+  align?: 'start' | 'center' | 'end';
+  fontColor?: 'main' | 'gray' | 'white' | 'gil-blue' | 'job-navy';
+  fontSize?: FontSize;
+  fontWeight?: 'light' | 'regular' | 'medium' | 'bold';
+  lineHeight?: 'narrow' | 'wide';
+}
+
+const Text: React.FC<TextProps> = ({
+  children,
+  className,
+  align = 'start',
+  fontColor = 'main',
+  fontSize = 'small',
+  fontWeight = 'medium',
+  lineHeight = 'narrow',
+}) => {
+  return (
+    <div
+      className={cn(
+        '_TEXT_',
+        className,
+        `text-align-${align}`,
+        `font-size-${fontSize}`,
+        `font-color-${fontColor}`,
+        `font-weight-${fontWeight}`,
+        `line-height-${lineHeight}`,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Text;

--- a/src/atoms/Text/index.ts
+++ b/src/atoms/Text/index.ts
@@ -1,0 +1,3 @@
+import Text from './Text';
+
+export default Text;

--- a/src/atoms/Text/style.scss
+++ b/src/atoms/Text/style.scss
@@ -1,0 +1,100 @@
+@import '/src/styles/';
+
+._TEXT_ {
+  font-size: $font-size-medium;
+  white-space: pre-wrap;
+
+  &.block {
+    display: block;
+  }
+  &.inline {
+    display: inline;
+  }
+
+  &.text-align {
+    &-start {
+      display: block;
+      text-align: start;
+    }
+    &-center {
+      display: block;
+      text-align: center;
+    }
+    &-end {
+      display: block;
+      text-align: end;
+    }
+  }
+
+  &.font-size {
+    &-xx-small {
+      font-size: $font-size-xx-small;
+    }
+    &-x-small {
+      font-size: $font-size-x-small;
+    }
+    &-small {
+      font-size: $font-size-small;
+    }
+    &-medium {
+      font-size: $font-size-medium;
+    }
+    &-large {
+      font-size: $font-size-large;
+    }
+    &-x-large {
+      font-size: $font-size-x-large;
+    }
+    &-xx-large {
+      font-size: $font-size-xx-large;
+    }
+    &-xxx-large {
+      font-size: $font-size-xxx-large;
+    }
+    &-xxxx-large {
+      font-size: $font-size-xxxx-large;
+    }
+  }
+
+  &.font-color {
+    &-main {
+      color: $text-main;
+    }
+    &-gray {
+      color: $text-gray;
+    }
+    &-gil-blue {
+      color: $gil-blue;
+    }
+    &-job-navy {
+      color: $job-navy;
+    }
+    &-white {
+      color: $white;
+    }
+  }
+
+  &.font-weight {
+    &-light {
+      font-weight: $font-weight-light;
+    }
+    &-regular {
+      font-weight: $font-weight-regular;
+    }
+    &-medium {
+      font-weight: $font-weight-medium;
+    }
+    &-bold {
+      font-weight: $font-weight-bold;
+    }
+  }
+
+  &.line-height {
+    &-narrow {
+      line-height: 1.5rem;
+    }
+    &-wide {
+      line-height: 2rem;
+    }
+  }
+}

--- a/src/atoms/Text/text.stories.tsx
+++ b/src/atoms/Text/text.stories.tsx
@@ -1,0 +1,61 @@
+import { Story, Meta } from '@storybook/react';
+import Text from '@src/atoms/Text';
+import { TextProps } from './Text';
+
+export default {
+  title: 'Atoms/Text',
+  component: Text,
+  parameters: {
+    docs: {
+      description: {
+        component: 'Text',
+      },
+    },
+  },
+  argTypes: {
+    align: {
+      options: ['start', 'center', 'end'],
+    },
+    fontColor: {
+      options: ['main', 'gray', 'white', 'gil-blue', 'job-navy'],
+    },
+    fontSize: {
+      options: [
+        'xx-small',
+        'x-small',
+        'small',
+        'medium',
+        'large',
+        'x-large',
+        'xx-large',
+        'xxx-large',
+        'xxxx-large',
+      ],
+    },
+    fontWeight: {
+      options: ['light', 'regular', 'medium', 'bold'],
+    },
+    lineHeight: {
+      options: ['narrow', 'wide'],
+    },
+    className: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} as Meta;
+
+const Template: Story<TextProps> = (props) => (
+  <Text {...props}>취업의 바다에서 길잡이가 되어주다, GilJOB</Text>
+);
+
+export const defaultText = Template.bind({});
+
+defaultText.args = {
+  align: 'start',
+  fontColor: 'main',
+  fontSize: 'small',
+  fontWeight: 'medium',
+  lineHeight: 'narrow',
+};

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import './style.scss';
+import Badge from '@src/atoms/Badge';
+import Text from '@src/atoms/Text';
+
+export interface CardProps {
+  step: '입문' | '통달';
+  category: string;
+  name: string;
+  exp: number;
+  participant: number;
+  author: string;
+}
+
+const Card: React.FC<CardProps> = ({
+  step,
+  category,
+  name,
+  exp,
+  participant,
+  author,
+}) => {
+  return (
+    <div className="_CARD_">
+      <div className="_TOP_">
+        <Badge step={step} align="end" />
+        <Text
+          align="start"
+          fontColor="gil-blue"
+          fontSize="large"
+          fontWeight="bold"
+          lineHeight="wide"
+        >
+          {category}
+        </Text>
+        <Text
+          align="start"
+          fontColor="white"
+          fontSize="xx-large"
+          fontWeight="bold"
+          lineHeight="wide"
+        >
+          {name}
+        </Text>
+      </div>
+      <div className="_MIDDLE_">
+        <Text
+          align="start"
+          fontColor="main"
+          fontSize="large"
+          fontWeight="medium"
+          lineHeight="wide"
+        >
+          {exp} Exp
+        </Text>
+        <Text
+          align="start"
+          fontColor="main"
+          fontSize="small"
+          fontWeight="medium"
+          lineHeight="wide"
+        >
+          {participant} 참여 중
+        </Text>
+      </div>
+      <div className="_BOTTOM_">
+        <Text
+          align="start"
+          fontColor="main"
+          fontSize="medium"
+          fontWeight="regular"
+          lineHeight="wide"
+        >
+          {author}
+        </Text>
+        {/* 이 아래로 아이콘과 버튼이 들어갑니다. */}
+      </div>
+    </div>
+  );
+};
+
+export default Card;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -4,7 +4,7 @@ import Badge from '@src/atoms/Badge';
 import Text from '@src/atoms/Text';
 
 export interface CardProps {
-  step: '입문' | '통달';
+  step: '입문' | '초급' | '중급' | '고급' | '통달';
   category: string;
   name: string;
   exp: number;

--- a/src/components/Card/card.stories.tsx
+++ b/src/components/Card/card.stories.tsx
@@ -1,0 +1,29 @@
+import { Story, Meta } from '@storybook/react';
+import Card from '@src/components/Card';
+import { CardProps } from './Card';
+
+export default {
+  title: 'Components/Card',
+  component: Card,
+  parameters: {
+    docs: {
+      description: {
+        component: 'Card',
+      },
+    },
+  },
+  argTypes: {},
+} as Meta;
+
+const Template: Story<CardProps> = (props) => <Card {...props} />;
+
+export const defaultText = Template.bind({});
+
+defaultText.args = {
+  step: '입문',
+  category: 'Front-End',
+  name: 'React',
+  exp: 100,
+  participant: 123,
+  author: '호랑이형님',
+};

--- a/src/components/Card/index.ts
+++ b/src/components/Card/index.ts
@@ -1,0 +1,3 @@
+import Card from './Card';
+
+export default Card;

--- a/src/components/Card/style.scss
+++ b/src/components/Card/style.scss
@@ -1,0 +1,34 @@
+@import '/src/styles/';
+
+._CARD_ {
+  width: 27.6rem;
+  height: 28.4rem;
+  border-radius: 2.5rem;
+  box-shadow: $box-shadow;
+
+  ._TOP_ {
+    display: flex;
+    flex-direction: column;
+    height: 8.1rem;
+    background-color: black;
+    border-radius: 2.5rem 2.5rem 0rem 0rem;
+    padding: 1.2rem 2.4rem;
+
+    > ._TEXT_ {
+      margin-top: 0.6rem;
+    }
+  }
+
+  ._MIDDLE_ {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding: 1.2rem 2.4rem;
+  }
+
+  ._BOTTOM_ {
+    display: flex;
+    flex-direction: column;
+    padding: 1.2rem 2.4rem;
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 

--- a/src/styles/_color.scss
+++ b/src/styles/_color.scss
@@ -1,0 +1,55 @@
+// Main color
+$gil-blue: #0389ff;
+$job-navy: #172965;
+
+// Custom Color
+$main-gray: #f3f3f3;
+$line-gray: #e3e3e3;
+$line-dark-gray: #b0b0b0;
+$text-main: #333333;
+$text-gray: #b6b6b6;
+
+// System Color
+$active-green: #69db7c;
+$inactive-red: #ff8787;
+$warning-red-1: #fff0ee;
+$warning-red-2: #f8d0d1;
+
+// Gray
+$white: #ffffff;
+$gray-0: #f2f2f2;
+$gray-1: #efeff2;
+$gray-2: #ebebee;
+$gray-3: #e0e0e5;
+$gray-4: #cacacc;
+$gray-5: #b1b1b3;
+$gray-6: #767679;
+$gray-7: #444348;
+$gray-8: #15141a;
+$black: #000000;
+
+// Red
+$red-5: #ff6b6b;
+$red-6: #fa5252;
+$red-7: #f03e3e;
+$red-8: #e03131;
+$red-9: #c92a2a;
+$red-10: #a51111;
+
+// Orange
+$orange-soft: #ffece2;
+$orange-hard: #f38119;
+
+// Green
+$green: #34c759;
+
+// Blue
+$blue-0: #f3f9ff;
+$blue-1: #e6f2ff;
+$blue-2: #c5e1ff;
+$blue-3: #92c7ff;
+$blue-4: #5facff;
+$blue-5: #1184ff;
+$blue-6: #0c6cd3;
+$blue-7: #004c9e;
+$blue-8: #003267;

--- a/src/styles/_font.scss
+++ b/src/styles/_font.scss
@@ -1,0 +1,10 @@
+// Font Face
+@font-face {
+  font-family: 'Noto Sans KR';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap);
+}
+
+// Font Family
+$font: 'Noto Sans KR', 'sans-serif';

--- a/src/styles/_variable.scss
+++ b/src/styles/_variable.scss
@@ -1,0 +1,18 @@
+$font-weight-light: 300;
+$font-weight-regular: 400;
+$font-weight-medium: 500;
+$font-weight-bold: 600;
+
+$font-size-xx-small: 1.2rem;
+$font-size-x-small: 1.3rem;
+$font-size-small: 1.4rem;
+$font-size-medium: 1.6rem;
+$font-size-large: 1.8rem;
+$font-size-x-large: 2rem;
+$font-size-xx-large: 2.2rem;
+$font-size-xxx-large: 3.6rem;
+$font-size-xxxx-large: 4.8rem;
+
+$hover-transition: ease-out 0.1s;
+
+$box-shadow: rgb(4 4 161 / 10%) 0px 6px 12px 0px;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,0 +1,8 @@
+@import 'font';
+@import 'color';
+@import 'variable';
+
+:root {
+  font-family: $font;
+  font-size: 62.5% !important; // 10px = 1rem
+}

--- a/src/utils/colorEnum.ts
+++ b/src/utils/colorEnum.ts
@@ -1,0 +1,52 @@
+enum ColorMap {
+  // Main color
+  $gilBlue = '#0389ff',
+  $jobNavy = '#172965',
+
+  // System Color
+  $activeGreen = '#69db7c',
+  $inactiveRed = '#ff8787',
+  $warningRed1 = '#fff0ee',
+  $warningRed2 = '#f8d0d1',
+
+  // Gray
+  $white = '#ffffff',
+  $gray0 = '#f2f2f2',
+  $gray1 = '#efeff2',
+  $gray2 = '#ebebee',
+  $gray3 = '#e0e0e5',
+  $gray4 = '#cacacc',
+  $gray5 = '#b1b1b3',
+  $gray6 = '#767679',
+  $gray7 = '#444348',
+  $gray8 = '#15141a',
+  $black = '#000000',
+
+  // Red
+  $red5 = '#ff6b6b',
+  $red6 = '#fa5252',
+  $red7 = '#f03e3e',
+  $red8 = '#e03131',
+  $red9 = '#c92a2a',
+  $red10 = '#a51111',
+
+  // Orange
+  $orangeSoft = '#ffece2',
+  $orangeHard = '#f38119',
+
+  // Green
+  $green = '#34c759',
+
+  // Blue
+  $blue0 = '#f3f9ff',
+  $blue1 = '#e6f2ff',
+  $blue2 = '#c5e1ff',
+  $blue3 = '#92c7ff',
+  $blue4 = '#5facff',
+  $blue5 = '#1184ff',
+  $blue6 = '#0c6cd3',
+  $blue7 = '#004c9e',
+  $blue8 = '#003267',
+}
+
+export default ColorMap;

--- a/src/utils/colorMap.ts
+++ b/src/utils/colorMap.ts
@@ -1,0 +1,52 @@
+const ColorMap = {
+  // Main color
+  $gilBlue: '#0389ff',
+  $jobNavy: '#172965',
+
+  // System Color
+  $activeGreen: '#69db7c',
+  $inactiveRed: '#ff8787',
+  $warningRed1: '#fff0ee',
+  $warningRed2: '#f8d0d1',
+
+  // Gray
+  $white: '#ffffff',
+  $gray0: '#f2f2f2',
+  $gray1: '#efeff2',
+  $gray2: '#ebebee',
+  $gray3: '#e0e0e5',
+  $gray4: '#cacacc',
+  $gray5: '#b1b1b3',
+  $gray6: '#767679',
+  $gray7: '#444348',
+  $gray8: '#15141a',
+  $black: '#000000',
+
+  // Red
+  $red5: '#ff6b6b',
+  $red6: '#fa5252',
+  $red7: '#f03e3e',
+  $red8: '#e03131',
+  $red9: '#c92a2a',
+  $red10: '#a51111',
+
+  // Orange
+  $orangeSoft: '#ffece2',
+  $orangeHard: '#f38119',
+
+  // Green
+  $green: '#34c759',
+
+  // Blue
+  $blue0: '#f3f9ff',
+  $blue1: '#e6f2ff',
+  $blue2: '#c5e1ff',
+  $blue3: '#92c7ff',
+  $blue4: '#5facff',
+  $blue5: '#1184ff',
+  $blue6: '#0c6cd3',
+  $blue7: '#004c9e',
+  $blue8: '#003267',
+};
+
+export default ColorMap;

--- a/src/utils/fontSize.ts
+++ b/src/utils/fontSize.ts
@@ -1,0 +1,12 @@
+type FontSize =
+  | 'xx-small'
+  | 'x-small'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'x-large'
+  | 'xx-large'
+  | 'xxx-large'
+  | 'xxxx-large';
+
+export default FontSize;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,6 @@
+// color
+export { default as ColorMap } from './colorMap';
+export type { default as ColorEnum } from './colorEnum';
+
+// font size
+export type { default as FontSize } from './fontSize';


### PR DESCRIPTION
## Summary
* 프로젝트 기본 설정을 일부 손봤습니다.
* 공통으로 사용할 SCSS 다수를 개발했습니다.
* Card 컴포넌트를 만들었습니다.
  * 단, 뒷 배경은 아직 배경 이미지로 사용할 이미지가 없으므로 검은 배경이고, 버튼 컴포넌트와 아이콘 컴포넌트가 만들어지지 않아서 해당 부분은 비어있습니다.

![image](https://user-images.githubusercontent.com/59731373/140553855-3390f8f3-1d16-42a8-8cfd-f0240d8d83c6.png)

## Detail
* Card 컴포넌트를 만들었습니다. ad55628
  * Card 컴포넌트를 만들 때, 재사용 가능성이 높다고 생각한 Badge 컴포넌트(3039d5a)와 Text 컴포넌트(d0a1cbc)도 만들었습니다.
  * 만든 컴포넌트 모두의 스토리를 만들었습니다.
* 공통으로 사용할 SCSS 다수를 만들었습니다. b1a09b0
  * 폰트 변수(97235ff), 색상 변수(b1b9c68), 기타 변수(335c664)를 만들었습니다.
  * 해당 변수들을 타입으로 쓸 수 있도록 했습니다. 7d9a2d6
* 기존 프로젝트 기본 환경 설정 중 일부를 수정했습니다.
  * 이제 프로젝트의 기본 SCSS는 `@src/styles` 경로에 있으므로, 기존 `additionalData` 구문을 제거했습니다. 630b0a4
  * ESLint 설정을 수정했습니다. 대부분 불필요한 rule을 off하는 수정입니다. 36cdb2b
  * `index.tsx`에 `import React from 'react'`를 추가했습니다. 0948cbb

## Todo
* Icon 컴포넌트를 만들어야 할 것 같습니다!
* 마찬가지로 Button 컴포넌트도 만들어야 할 것 같습니다.