### PR TITLE
[GILJOB-50] fix: 글꼴 장평 추가

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -5,4 +5,5 @@
 :root {
   font-family: $font;
   font-size: 62.5% !important; // 10px = 1rem
+  letter-spacing: -0.05rem;
 }


### PR DESCRIPTION
## Summary

전체 글꼴에 장평 추가했습니다!

## Detail

모든 텍스트에 장평 -5% 적용되야 합니다.